### PR TITLE
Note about 'New Window' changing to 'New File'

### DIFF
--- a/en-GB/lessons/ASCII Art/ASCII Art - notes.md
+++ b/en-GB/lessons/ASCII Art/ASCII Art - notes.md
@@ -8,7 +8,7 @@ embeds: "*.png"
 This project teaches children how to run a simple Python program, and how to print text to the screen. Children will write programs to print ASCII art to the screen.
 
 #Resources
-For this project, Python will need to be installed. It is recommended that version 3.2 of Python is installed.
+For this project, Python will need to be installed. It is recommended that version 3.2 of Python is installed. Note that on newer versions of Python the `File → New Window` menu option has been replaced by `File → New File`.
 
 Children can also make use of the materials which accompany these challenges. Files included in the 'Project Resources' folder (found under the 'Download Project Materials' link):
 


### PR DESCRIPTION
I have just used this worksheet for the first time and we found that the option on the 'File' menu is 'New File' not 'New Window'. It looks like a change in Python 3.3. I thought about making a change to the worksheet itself but the notes recommend 3.2 so I thought it would be more appropriate to add a warning for the volunteer.